### PR TITLE
Ignore `devDependencies` in dependabot alerts

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/**"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Ignore `devDependencies for alerts`
* It [looks like](https://github.com/facebook/create-react-app/issues/11174) dev tools aren't really vulnerable in the same way production dependencies are


